### PR TITLE
LIBHYDRA-363. Fix timeout error handling

### DIFF
--- a/app/assets/javascripts/resource.js
+++ b/app/assets/javascripts/resource.js
@@ -22,6 +22,11 @@ $(document).on('turbolinks:load', function() {
     }
   }
 
+  function displayErrors(errorHtml) {
+    errorDiv.innerHTML = errorHtml;
+    window.scrollTo(0, 0);
+  }
+
   // Ensure submit button is enabled on form load
   enableSubmitButton();
 
@@ -44,8 +49,7 @@ $(document).on('turbolinks:load', function() {
 
       let errorDisplay = data.error_display;
       if (errorDisplay) {
-        errorDiv.innerHTML = errorDisplay;
-        window.scrollTo(0, 0);
+        displayErrors(errorDisplay)
         return;
       }
 
@@ -56,11 +60,15 @@ $(document).on('turbolinks:load', function() {
       }
     });
     element.addEventListener("ajax:error", () => {
-      enableSubmitButton();
       const [data, _status, xhr] = event.detail;
-      errors = data.errors
-      let alertText = errors.join("\n");
-      alert(alertText);
+
+      enableSubmitButton();
+
+      let errorDisplay = data.error_display;
+      if (errorDisplay) {
+        displayErrors(errorDisplay)
+        return;
+      }
     });
   }
 });

--- a/app/controllers/resource_controller.rb
+++ b/app/controllers/resource_controller.rb
@@ -89,7 +89,7 @@ class ResourceController < ApplicationController
       rescue Timeout::Error
         # Handle timeout
         status = 'Error'
-        errors = ['Timeout']
+        errors = [JSON.generate([I18n.t('resource_update_timeout_error')])]
       end
       { status: status, errors: errors }
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,7 @@ en:
   resource_update_successful: 'Update successful'
   resource_update_failed: 'Update failed'
   resource_update_no_change: 'Please make a change before submitting.'
+  resource_update_timeout_error: 'Timeout error. Fedora has taken too long to respond. Please report this error and check back in a few minutes as your changes may have been saved.'
   activerecord:
     attributes:
       datatype:


### PR DESCRIPTION
Fixed display of timeout errors. Prior to this change, the error was
not displayed, because of an undefined "errors" variable in the
"resource.js" JavaScript. Corrected the timeout error handling to
ensure that a message (defined in the en.yml file) is displayed.

In "resource_controller.rb" modified the generation of the timeout
error to be passed back as a JSON string, to match the errors coming
from Plastron.

https://issues.umd.edu/browse/LIBHYDRA-363