### PR TITLE
LIBHYDRA-430. Enable Docker start script to use env var for db host

### DIFF
--- a/bin/docker_start.sh
+++ b/bin/docker_start.sh
@@ -5,7 +5,11 @@ service ssh start
 
 # wait for the database to be up
 echo -n Checking database host/port...
-until nc -z archelon-db 5432; do
+
+# Set DATABASE_HOST to ARCHELON_DATABASE_HOST or a default ("archelon-db")
+DATABASE_HOST="${ARCHELON_DATABASE_HOST:-archelon-db}"
+
+until nc -z $DATABASE_HOST 5432; do
   echo -n .
   sleep 1
 done


### PR DESCRIPTION
Modified "bin/docker_start.sh" to use the "ARCHELON_DATABASE_HOST"
environment variable for determining the Archelon database host, if
present.

This is needed for Kubernetes, where the Archelon database is at
"fcrepo-archelon-db".

https://issues.umd.edu/browse/LIBHYDRA-430