### PR TITLE
RESQUE. Use ":resque" in production, ":inline" in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,13 +305,28 @@ See [docs/ActionCable.md](docs/ActionCable.md) for more information.
 
 *Experimental support for Resque as the ActiveJob adapter*
 
-To run a Redis instance via Docker:
+Archelon is configured to use the Resque queue adapter in production. To
+enable Reque for development:
+
+1) Edit the "config/environments/development.rb" file, changing:
+
+```
+config.active_job.queue_adapter = :inline
+```
+
+to
+
+```
+config.active_job.queue_adapter = :resque
+```
+
+2) Run a Redis instance via Docker:
 
 ```
 docker run --rm --name archelon-redis -p 6379:6379 redis
 ```
 
-To run the Resque worker Rake task:
+3) Run the Resque worker Rake task:
 
 ```
 LOGGING=1 QUEUE=* bundle exec rails resque:work

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,7 +56,7 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
-  # config.active_job.queue_adapter     = :resque
+  config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "railsdiff_#{Rails.env}"
 
   config.action_mailer.perform_caching = false


### PR DESCRIPTION
Modified the configuration so that the ":resque" queue adapter is used
in the "production" environment, while the ":inline" queue adapter is
used for "development".

The "db:reset" Rake task, used to setup the application, performs
ActiveJob queuing (via the "after_save" callback on the "Vocabulary"
model). Using the ":inline" adapter by default removes the need to have
a running Redis server to setup and test the application. This
simplifies both development setup and the Jenkins CI configuration.

Modified existing instructions in the README to indicate how to modify
the development environment to use the ":resque" adapter when needed.